### PR TITLE
Matplotlib Fix For Windows

### DIFF
--- a/env_installer/jlab_server.yaml
+++ b/env_installer/jlab_server.yaml
@@ -5,16 +5,16 @@ dependencies:
   - conda
   - ipywidgets >= 8.0.1
   - jupyterlab 4.4.6
-  - ipympl >= 0.8.2
-  - matplotlib-base
-  - numpy
-  - pandas
   - pip
   - python 3.12*
-  - scipy
   - pip:
     - mito-ai
     - mitosheet
+    - "numpy==2.1.*"
+    - "matplotlib==3.9.2"
+    - "ipympl>=0.8.2"
+    - "pandas"
+    - "scipy"
 platforms:
   - linux-64
   - linux-aarch64


### PR DESCRIPTION
## Background 

Previously, plotting anything (using matplotlib) on Windows would cause the kernel to crash. This issue was due to the matplotlib backend. We know this because switching the backend to something like Agg would not crash the kernel, while choosing an interactive option would cause a crash.

According to ChatGPT:

> Your kernel says: Python 3.12.11 | packaged by conda-forge. If Matplotlib/NumPy came from pip wheels compiled for the python.org toolchain, you can segfault on first draw even with the inline backend.

ChatGPT also suggested:

```bash
python -m pip uninstall -y matplotlib numpy kiwisolver pillow cycler contourpy fonttools pyparsing
python -m pip install --no-cache-dir "numpy==2.1.*" "matplotlib==3.9.2"
```

ChatGPT made these suggestions because:

- We deliberately pin to a known-good 3.9.x Matplotlib on Windows while a new 3.10.x regression is being investigated (there are fresh Sept 2025 reports of Jupyter kernels crashing on Windows with 3.10). [Github](https://github.com/matplotlib/matplotlib/issues/30501?utm_source=chatgpt.com)
- Staying on the same toolchain for Python ↔ NumPy ↔ Matplotlib matters; mixing conda-forge Python with unrelated pip wheels is a classic crash recipe on Windows. Matplotlib’s own docs stress backend/config consistency; environment-level fixes like MPLCONFIGDIR help with cache/fonts but won’t solve binary ABI mismatches. 

## The Fix

Based on ChatGPT's suggestion, I've moved most of the packages into the pip section of the `jlab_server.yml` file, and pinned very specific version of numpy and matplotlib. 

Note that you'll want to manually find and delete **all** environments. You can find a list of environments by looking under Manage Python Environments_. Doing this will show the setup env message on the welcome screen, and will install Jupyter Lab. 

<img width="362" height="308" alt="image" src="https://github.com/user-attachments/assets/07235e43-5194-4cac-9f32-8f83eb720a8e" />