### PR TITLE
Update Download Links

### DIFF
--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -1250,7 +1250,7 @@ export class JupyterApplication implements IApplication, IDisposable {
 
   checkForUpdates(showDialog: 'on-new-version' | 'always') {
     fetch(
-      'https://github.com/jupyterlab/jupyterlab-desktop/releases/latest/download/latest.yml'
+      'https://github.com/mito-ds/mito-desktop/releases/latest/download/latest.yml'
     )
       .then(async response => {
         try {

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -659,7 +659,7 @@ export class JupyterApplication implements IApplication, IDisposable {
       EventTypeMain.LaunchInstallerDownloadPage,
       () => {
         shell.openExternal(
-          'https://github.com/jupyterlab/jupyterlab-desktop/releases'
+          'https://trymito.io/downloads'
         );
       }
     );


### PR DESCRIPTION
- Updated the link used to check the current version on the releases page.
- Updated the download link when there is a new version.

On Windows, the update message automatically pops up. On MacOS, you have to click on the hamberger icon, and select _Check for updates_. 