### PR TITLE
Make Sure Default Env. is Bundled Env.

### DIFF
--- a/src/main/registry.ts
+++ b/src/main/registry.ts
@@ -64,6 +64,7 @@ export interface IRegistry {
   environmentListUpdated: ISignal<this, void>;
   clearUserSetPythonEnvs(): void;
   bundledEnvironmentIsLatest(): boolean;
+  isDefaultEnvironmentBundled(): boolean;
 }
 
 export const SERVER_TOKEN_PREFIX = 'jlab:srvr:';
@@ -92,6 +93,12 @@ export class Registry implements IRegistry, IDisposable {
 
     try {
       const defaultEnv = this._resolveEnvironmentSync(pythonPath);
+      if (defaultEnv.path !== getBundledPythonPath()) {
+        // If the default environment is not the bundled one, don't set it (this._defaultEnv).
+        // This is to prevent the default environment from being set to one of the user's 
+        // other environments. We should only be working with the bundled environment.
+        return;
+      }
 
       if (defaultEnv) {
         this._defaultEnv = defaultEnv;
@@ -672,6 +679,15 @@ export class Registry implements IRegistry, IDisposable {
     }
 
     return bundledEnvInstallationLatest;
+  }
+
+  isDefaultEnvironmentBundled(): boolean {
+    if (!this._defaultEnv) {
+      return false;
+    }
+
+    const bundledPythonPath = getBundledPythonPath();
+    return this._defaultEnv.path === bundledPythonPath;
   }
 
   private _updateEnvironments() {

--- a/src/main/welcomeview/welcomeview.ts
+++ b/src/main/welcomeview/welcomeview.ts
@@ -648,10 +648,9 @@ export class WelcomeView {
     
             if (status === 'SUCCESS') {
               setTimeout(() => {
-                showNotificationPanel('Installation completed!', true);
-                // Reload the welcome view to refresh the UI, 
-                // and set the new environment as the default.
-                window.location.reload();
+                // Restart the app to refresh the UI, 
+                // which will set the new environment as the default.
+                sendMessageToMain('${EventTypeMain.RestartApp}');
               }, 2000);
             }
           });
@@ -720,11 +719,12 @@ export class WelcomeView {
     this._registry
       .getDefaultEnvironment()
       .then(() => {
-        this.enableLocalServerActions(true);
         // Check if the default environment is the bundled one
         if (!this._registry.isDefaultEnvironmentBundled()) {
+          this.enableLocalServerActions(false);
           this.showNotification(installMessage, false);
         } else {
+          this.enableLocalServerActions(true);
           this.showNotification('', false);
         }
       })

--- a/src/main/welcomeview/welcomeview.ts
+++ b/src/main/welcomeview/welcomeview.ts
@@ -712,34 +712,25 @@ export class WelcomeView {
   }
 
   private async _onEnvironmentListUpdated() {
+    const installMessage = `
+      <div class="warning-message">
+        Before you start, we need to set up your workspace. <a class="install-python-button" href="javascript:void(0);" onclick="sendMessageToMain('${EventTypeMain.InstallBundledPythonEnv}')">Get Started</a>
+      </div>
+    `;
     this._registry
       .getDefaultEnvironment()
       .then(() => {
         this.enableLocalServerActions(true);
         // Check if the default environment is the bundled one
         if (!this._registry.isDefaultEnvironmentBundled()) {
-          this.showNotification(
-            `
-            <div class="warning-message">
-              Before you start, we need to set up your workspace. <a class="install-python-button" href="javascript:void(0);" onclick="sendMessageToMain('${EventTypeMain.InstallBundledPythonEnv}')">Get Started</a>
-            </div>
-          `,
-            false
-          );
+          this.showNotification(installMessage, false);
         } else {
           this.showNotification('', false);
         }
       })
       .catch(() => {
         this.enableLocalServerActions(false);
-        this.showNotification(
-          `
-          <div class="warning-message">
-            Before you start, we need to set up your workspace. <a class="install-python-button" href="javascript:void(0);" onclick="sendMessageToMain('${EventTypeMain.InstallBundledPythonEnv}')">Get Started</a>
-          </div>
-        `,
-          false
-        );
+        this.showNotification(installMessage, false);
       });
   }
 

--- a/src/main/welcomeview/welcomeview.ts
+++ b/src/main/welcomeview/welcomeview.ts
@@ -713,7 +713,19 @@ export class WelcomeView {
       .getDefaultEnvironment()
       .then(() => {
         this.enableLocalServerActions(true);
-        this.showNotification('', false);
+        // Check if the default environment is the bundled one
+        if (!this._registry.isDefaultEnvironmentBundled()) {
+          this.showNotification(
+            `
+            <div class="warning-message">
+              Before you start, we need to set up your workspace. <a class="install-python-button" href="javascript:void(0);" onclick="sendMessageToMain('${EventTypeMain.InstallBundledPythonEnv}')">Get Started</a>
+            </div>
+          `,
+            false
+          );
+        } else {
+          this.showNotification('', false);
+        }
       })
       .catch(() => {
         this.enableLocalServerActions(false);

--- a/src/main/welcomeview/welcomeview.ts
+++ b/src/main/welcomeview/welcomeview.ts
@@ -648,7 +648,10 @@ export class WelcomeView {
     
             if (status === 'SUCCESS') {
               setTimeout(() => {
-                showNotificationPanel('', true);
+                showNotificationPanel('Installation completed!', true);
+                // Reload the welcome view to refresh the UI, 
+                // and set the new environment as the default.
+                window.location.reload();
               }, 2000);
             }
           });


### PR DESCRIPTION
Using the `getBundledPythonPath` function we can get a string representation of the file path for where the bundled dir should be located. This, for example on macOS, will look like:

```
/Users/nawaz/Library/Mito/jlab_server/bin/python
```

On Windows, the function will return the `AppData` path. 

Using this path, we can compare it to the `defaultEnv.path` that is discovered when the app starts, and force the user to setup a Mito Python env if they don't already have one.  