### PR TITLE
Use bundled env

### DIFF
--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -772,6 +772,7 @@ export class JupyterApplication implements IApplication, IDisposable {
               addUserSetEnvironment(installPath, true);
               const pythonPath = pythonPathForEnvPath(installPath, true);
               this._registry.addEnvironment(pythonPath);
+              this._registry.setDefaultPythonPath(pythonPath);
             }
           },
           get forceOverwrite() {

--- a/src/main/config/settings.ts
+++ b/src/main/config/settings.ts
@@ -225,6 +225,7 @@ export class UserSettings {
     const userSettingsPath = UserSettings.getUserSettingsPath();
     const userSettings: { [key: string]: any } = {};
 
+
     for (let key in SettingType) {
       const setting = this._settings[key];
       if (setting.differentThanDefault) {

--- a/src/main/registry.ts
+++ b/src/main/registry.ts
@@ -64,6 +64,7 @@ export interface IRegistry {
   environmentListUpdated: ISignal<this, void>;
   clearUserSetPythonEnvs(): void;
   bundledEnvironmentIsLatest(): boolean;
+  isDefaultEnvironmentBundled(): boolean;
 }
 
 export const SERVER_TOKEN_PREFIX = 'jlab:srvr:';
@@ -92,6 +93,12 @@ export class Registry implements IRegistry, IDisposable {
 
     try {
       const defaultEnv = this._resolveEnvironmentSync(pythonPath);
+      if (defaultEnv.path !== getBundledPythonPath()) {
+        // If the default environment is not the bundled one, don't set it (this._defaultEnv).
+        // This is to prevent the default environment from being set to one of the user's 
+        // other environments. We should only be working with the bundled environment.
+        return;
+      }
 
       if (defaultEnv) {
         this._defaultEnv = defaultEnv;
@@ -672,6 +679,15 @@ export class Registry implements IRegistry, IDisposable {
     }
 
     return bundledEnvInstallationLatest;
+  }
+
+  isDefaultEnvironmentBundled(): boolean {
+    if (!this._defaultEnv) {
+      return false;
+    }
+
+    const bundledPythonPath = getBundledPythonPath();
+    return this._defaultEnv.path === bundledPythonPath;
   }
 
   private _updateEnvironments() {

--- a/src/main/sessionwindow/sessionwindow.ts
+++ b/src/main/sessionwindow/sessionwindow.ts
@@ -151,7 +151,22 @@ export class SessionWindow implements IDisposable {
       workingDirectory: this._sessionConfig.resolvedWorkingDirectory
     };
 
-    const pythonPath = this._wsSettings.getValue(SettingType.pythonPath);
+    /* 
+    This is the Python path that we actually use in the session.
+    By always using the bundledPythonPath, reguardless of what the default is, 
+    we ensure that the user always has the correct environment. 
+
+    Originally, this line of code was the following: 
+      
+      const pythonPath = this._wsSettings.getValue(SettingType.pythonPath);
+
+    This would give us the wrong environment because the getValue function 
+    prioritizes the workspace settings over the other settings. The workspace 
+    settings are read from the following path: 
+
+      return path.join(workingDirectory, '.jupyter', 'desktop-settings.json');
+    */
+    const pythonPath = getBundledPythonPath()
 
     if (pythonPath) {
       serverOptions.environment = this._registry.getEnvironmentByPath(

--- a/src/main/welcomeview/welcomeview.ts
+++ b/src/main/welcomeview/welcomeview.ts
@@ -648,10 +648,9 @@ export class WelcomeView {
     
             if (status === 'SUCCESS') {
               setTimeout(() => {
-                showNotificationPanel('Installation completed!', true);
-                // Reload the welcome view to refresh the UI, 
-                // and set the new environment as the default.
-                window.location.reload();
+                // Restart the app to refresh the UI, 
+                // which will set the new environment as the default.
+                sendMessageToMain('${EventTypeMain.RestartApp}');
               }, 2000);
             }
           });
@@ -720,11 +719,12 @@ export class WelcomeView {
     this._registry
       .getDefaultEnvironment()
       .then(() => {
-        this.enableLocalServerActions(true);
         // Check if the default environment is the bundled one
         if (!this._registry.isDefaultEnvironmentBundled()) {
+          this.enableLocalServerActions(false);
           this.showNotification(installMessage, false);
         } else {
+          this.enableLocalServerActions(true);
           this.showNotification('', false);
         }
       })

--- a/src/main/welcomeview/welcomeview.ts
+++ b/src/main/welcomeview/welcomeview.ts
@@ -712,34 +712,25 @@ export class WelcomeView {
   }
 
   private async _onEnvironmentListUpdated() {
+    const installMessage = `
+      <div class="warning-message">
+        Before you start, we need to set up your workspace. <a class="install-python-button" href="javascript:void(0);" onclick="sendMessageToMain('${EventTypeMain.InstallBundledPythonEnv}')">Get Started</a>
+      </div>
+    `;
     this._registry
       .getDefaultEnvironment()
       .then(() => {
         this.enableLocalServerActions(true);
         // Check if the default environment is the bundled one
         if (!this._registry.isDefaultEnvironmentBundled()) {
-          this.showNotification(
-            `
-            <div class="warning-message">
-              Before you start, we need to set up your workspace. <a class="install-python-button" href="javascript:void(0);" onclick="sendMessageToMain('${EventTypeMain.InstallBundledPythonEnv}')">Get Started</a>
-            </div>
-          `,
-            false
-          );
+          this.showNotification(installMessage, false);
         } else {
           this.showNotification('', false);
         }
       })
       .catch(() => {
         this.enableLocalServerActions(false);
-        this.showNotification(
-          `
-          <div class="warning-message">
-            Before you start, we need to set up your workspace. <a class="install-python-button" href="javascript:void(0);" onclick="sendMessageToMain('${EventTypeMain.InstallBundledPythonEnv}')">Get Started</a>
-          </div>
-        `,
-          false
-        );
+        this.showNotification(installMessage, false);
       });
   }
 

--- a/src/main/welcomeview/welcomeview.ts
+++ b/src/main/welcomeview/welcomeview.ts
@@ -713,7 +713,19 @@ export class WelcomeView {
       .getDefaultEnvironment()
       .then(() => {
         this.enableLocalServerActions(true);
-        this.showNotification('', false);
+        // Check if the default environment is the bundled one
+        if (!this._registry.isDefaultEnvironmentBundled()) {
+          this.showNotification(
+            `
+            <div class="warning-message">
+              Before you start, we need to set up your workspace. <a class="install-python-button" href="javascript:void(0);" onclick="sendMessageToMain('${EventTypeMain.InstallBundledPythonEnv}')">Get Started</a>
+            </div>
+          `,
+            false
+          );
+        } else {
+          this.showNotification('', false);
+        }
       })
       .catch(() => {
         this.enableLocalServerActions(false);

--- a/src/main/welcomeview/welcomeview.ts
+++ b/src/main/welcomeview/welcomeview.ts
@@ -648,7 +648,10 @@ export class WelcomeView {
     
             if (status === 'SUCCESS') {
               setTimeout(() => {
-                showNotificationPanel('', true);
+                showNotificationPanel('Installation completed!', true);
+                // Reload the welcome view to refresh the UI, 
+                // and set the new environment as the default.
+                window.location.reload();
               }, 2000);
             }
           });

--- a/src/main/welcomeview/welcomeview.ts
+++ b/src/main/welcomeview/welcomeview.ts
@@ -648,9 +648,7 @@ export class WelcomeView {
     
             if (status === 'SUCCESS') {
               setTimeout(() => {
-                // Restart the app to refresh the UI, 
-                // which will set the new environment as the default.
-                sendMessageToMain('${EventTypeMain.RestartApp}');
+                showNotificationPanel('', true);
               }, 2000);
             }
           });


### PR DESCRIPTION
Goal is to always use the bundled environment instead of the default environment so that users are guaranteed to use an environment that has mito-ai installed in it. 

Without this, users might install mito desktop, get set to an existing environment (especially if they have anaconda navigator installed) and not have mito-ai. This would not make sense for a user who is downloading mito-desktop! 