### PR TITLE
App uses full screen size

### DIFF
--- a/src/main/sessionwindow/sessionwindow.ts
+++ b/src/main/sessionwindow/sessionwindow.ts
@@ -135,6 +135,7 @@ export class SessionWindow implements IDisposable {
     });
 
     this._window.setMenuBarVisibility(false);
+    this._window.maximize();
     this._window.show();
 
     this._registerListeners();


### PR DESCRIPTION
The app window is now maximized, then displayed. 

On both MacOS and Windows, this means the default window will take up the full screen. However, on Windows, when you drag to move the window around, the app will resize to the previously set height and width. This does not happen on MacOS. This behavior seems to the default for both Chrome and Cursor.