### PR TITLE
Added sideload flag

### DIFF
--- a/dev/start-mito-sideloaded.sh
+++ b/dev/start-mito-sideloaded.sh
@@ -182,8 +182,8 @@ launch_mito_desktop() {
 export MITO_PYTHON_PATH="$python_path"
 export JUPYTERLAB_DESKTOP_PYTHON_PATH="$python_path"
 
-# Launch mito-desktop
-exec yarn start "\$@"
+# Launch mito-desktop with sideload flag
+exec yarn start --sideload "\$@"
 EOF
     
     chmod +x "$temp_launch_script"

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -103,6 +103,18 @@ export function getBundledPythonEnvPath(): string {
 }
 
 export function getBundledPythonPath(): string {
+  // Check if sideload flag is present (--sideload in process.argv)
+  const isSideload = process.argv.includes('--sideload');
+  
+  if (isSideload) {
+    // If we are sideloading, we want to use the Python path from the environment variable.
+    // This is set in the start-mito-sideloaded.sh script, and will give us the python path 
+    // from the conda environment where the mito-ai development version is installed.
+    const envPythonPath = process.env.MITO_PYTHON_PATH || process.env.JUPYTERLAB_DESKTOP_PYTHON_PATH;
+    if (envPythonPath) {
+      return envPythonPath;
+    }
+  }
   return pythonPathForEnvPath(getBundledPythonEnvPath(), true);
 }
 


### PR DESCRIPTION
## Problem

I've been having some trouble sideloading my local mito/mito-ai directory into the desktop app. It seemed like running the script was not installing the local version of mito-ai. 

## Solution 

I added a `--sideload` flag that signals the desktop app to use a Python path from environment variables (set by the script) instead of the bundled Python environment.

With the flag:

```
/opt/homebrew/Caskroom/miniconda/base/envs/mito-dev/bin/python
```

Without:

```
/Users/nawaz/Library/Mito/jlab_server/bin/python
```

Doing a `-m pip list` on either of these enviornments reveals that the first env has the local mito-ai package, while the latter uses the bundled version (from PyPi). 

## Behind the Scenes

The `start-mito-sideloaded.sh` script creates/updates a conda environment with the local mito-ai package installed in editable mode, and sets environment variables pointing to that environment's Python interpreter. When the `--sideload` flag is present, `getBundledPythonPath()` uses those environment variables instead of the default bundled path