### PR TITLE
Bump node version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '24.x'
           cache: 'yarn'
 
       - name: Install dependencies


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Update GitHub Actions publish workflow to use Node.js 24.x instead of 20.x.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f25cc6717a821e392ee7eccda981b665ca4a0c4d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->